### PR TITLE
Exit the test script early if eslint fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-dev",
   "description": "Automated versioning for github projects based on semver labels",
   "scripts": {
-    "test": "eslint .; mocha --forbid-only \"test/**/*.test.js\""
+    "test": "eslint . && mocha --forbid-only \"test/**/*.test.js\""
   },
   "keywords": [],
   "author": "Jake Champion <me@jakechampion.name>",


### PR DESCRIPTION
I think using `eslint .; mocha ...` makes the npm script never check the exit code of the `eslint` command.

Switching from `;` to `&&` will make the eslint exit code be returned if it is non-zero (eslint has failed).