### PR TITLE
throw an error if multiple release labels were applied to the merged pull-request

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const core = require('@actions/core');
 const github = require('@actions/github');
-const { highestReleaseTypeFromLabels, incrementTag } = require('./lib');
+const { releaseTypeFromLabels, incrementTag } = require('./lib');
 
 function getLabelNamesFromPullRequest(payload) {
   const labels = payload.pull_request.labels.map(label => {
@@ -49,7 +49,7 @@ async function main() {
     octokit = new github.GitHub(core.getInput('github-token'));
     // Increment the last tag based on release labels if found.
     const labels = getLabelNamesFromPullRequest(payload);
-    const releaseType = highestReleaseTypeFromLabels(labels);
+    const releaseType = releaseTypeFromLabels(labels);
     if (!releaseType) {
       console.log(
         'No version label set. Cancelling automated versioning action.'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,19 +1,28 @@
 'use strict';
 const semver = require('semver');
 
+function isTrue(bool) {
+    return bool === true;
+}
+
 module.exports = {
-    highestReleaseTypeFromLabels(labels = []) {
+    releaseTypeFromLabels(labels = []) {
         // Possible release types
         // 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease'
         const major = labels.includes('release:major');
+        const minor = labels.includes('release:minor');
+        const patch = labels.includes('release:patch');
+        const appliedReleaseLabels = [major, minor, patch].filter(isTrue);
+        if (appliedReleaseLabels.length > 1) {
+            const errorMessage = 'More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.';
+            throw new Error(errorMessage + '\n' + `The labels which were applied are: ${JSON.stringify(labels, undefined, 1)}`);
+        }
         if (major) {
             return 'major';
         }
-        const minor = labels.includes('release:minor');
         if (minor) {
             return 'minor';
         }
-        const patch = labels.includes('release:patch');
         if (patch) {
             return 'patch';
         }

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const proclaim = require('proclaim');
-const { highestReleaseTypeFromLabels, incrementTag } = require('../lib');
+const { releaseTypeFromLabels, incrementTag } = require('../lib');
 
-describe('highestReleaseTypeFromLabels', function () {
+describe('releaseTypeFromLabels', function () {
 	const majorLabel = 'release:major';
 	const minorLabel = 'release:minor';
 	const patchLabel = 'release:patch';
@@ -15,39 +15,53 @@ describe('highestReleaseTypeFromLabels', function () {
 
 	it('should return the corresponding release type given a single Origami release label', function () {
 		for (const { expectedType, releaseLabel } of Object.entries(typeToReleaseLabel)) {
-			const actualType = highestReleaseTypeFromLabels([releaseLabel]);
+			const actualType = releaseTypeFromLabels([releaseLabel]);
 			proclaim.equal(actualType, expectedType);
 		}
 	});
 
-	it('should return the highest release type given multiple labels', function () {
+	it('should throw an error if given multiple release type labels', function () {
 		const data = [
 			{
 				labels: ['release:major-test-dummy', minorLabel, majorLabel, patchLabel, 'zzz', 'aaa', '111'],
-				expectedType: 'major',
+				errorMessage: `More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.
+The labels which were applied are: [
+ "release:major-test-dummy",
+ "release:minor",
+ "release:major",
+ "release:patch",
+ "zzz",
+ "aaa",
+ "111"
+]`,
 			},
 			{
 				labels: ['release:lies', patchLabel, 'zzz', minorLabel, 'aaa', '111'],
-				expectedType: 'minor',
-			},
-			{
-				labels: ['release:major-test-dummy', 'zzz', 'aaa', '111', patchLabel],
-				expectedType: 'patch',
-			},
+				errorMessage: `More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.
+The labels which were applied are: [
+ "release:lies",
+ "release:patch",
+ "zzz",
+ "release:minor",
+ "aaa",
+ "111"
+]`,
+			}
 		];
-		for (const { labels, expectedType } of data) {
-			const actualType = highestReleaseTypeFromLabels(labels);
-			proclaim.equal(actualType, expectedType);
+		for (const { labels, errorMessage } of data) {
+			proclaim.throws(function(){
+				releaseTypeFromLabels(labels);
+			}, errorMessage);
 		}
 	});
 
 	it('should return `null` given no Origami release labels', function () {
-		const actualType = highestReleaseTypeFromLabels(['release:major-test-dummy', 'zzz', 'aaa', '111']);
+		const actualType = releaseTypeFromLabels(['release:major-test-dummy', 'zzz', 'aaa', '111']);
 		proclaim.isNull(actualType);
 	});
 
 	it('should return `null` given no labels at all', function () {
-		const actualType = highestReleaseTypeFromLabels([]);
+		const actualType = releaseTypeFromLabels([]);
 		proclaim.isNull(actualType);
 	});
 });


### PR DESCRIPTION
The current behavior which exists in origami-version is to choose the highest release label if multiple were applied. We should change this behavior to throw an error because if multiple release labels are applied, we don't actually know that they wanted to use the highest label for the release, it is safer to throw an error.

Future work we could do in origami-version is to run the action on every pushed commit to the pull-request and fail the build if the pull-request has multiple release labels applied. This would stop the pull-request from ever being able to be merged with multiple release labels applied.