### PR TITLE
Add ability to release beta versions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,15 +33,12 @@ module.exports = {
 		'prefer-const': 1,
 		'no-const-assign': 2
 	},
-	'globals': {
-		'after': true,
-		'afterEach': true,
-		'before': true,
-		'beforeEach': true,
-		'describe': true,
-		'fetch': true,
-		'it': true,
-		'xdescribe': true,
-		'xit': true
-	}
+	overrides: [
+		{
+			files: ['test/**/*.test.js'],
+			env: {
+				mocha: true,
+			}
+		},
+	],
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const core = require('@actions/core');
 const github = require('@actions/github');
-const { highestReleaseTypeFromLabels, incrementTag } = require('./lib');
+const { releaseTypeFromLabels, incrementTag } = require('./lib');
 
 function getLabelNamesFromPullRequest(payload) {
   const labels = payload.pull_request.labels.map(label => {
@@ -49,7 +49,7 @@ async function main() {
     octokit = new github.GitHub(core.getInput('github-token'));
     // Increment the last tag based on release labels if found.
     const labels = getLabelNamesFromPullRequest(payload);
-    const releaseType = highestReleaseTypeFromLabels(labels);
+    const releaseType = releaseTypeFromLabels(labels);
     if (!releaseType) {
       console.log(
         'No version label set. Cancelling automated versioning action.'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,19 +1,28 @@
 'use strict';
 const semver = require('semver');
 
+function isTrue(bool) {
+    return bool === true;
+}
+
 module.exports = {
-    highestReleaseTypeFromLabels(labels = []) {
+    releaseTypeFromLabels(labels = []) {
         // Possible release types
         // 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease'
         const major = labels.includes('release:major');
+        const minor = labels.includes('release:minor');
+        const patch = labels.includes('release:patch');
+        const appliedReleaseLabels = [major, minor, patch].filter(isTrue);
+        if (appliedReleaseLabels.length > 1) {
+            const errorMessage = 'More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.';
+            throw new Error(errorMessage + '\n' + `The labels which were applied are: ${JSON.stringify(labels, undefined, 1)}`);
+        }
         if (major) {
             return 'major';
         }
-        const minor = labels.includes('release:minor');
         if (minor) {
             return 'minor';
         }
-        const patch = labels.includes('release:patch');
         if (patch) {
             return 'patch';
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ module.exports = {
         const major = labels.includes('release:major');
         const minor = labels.includes('release:minor');
         const patch = labels.includes('release:patch');
+        const beta = labels.includes('release:beta');
         const appliedReleaseLabels = [major, minor, patch].filter(isTrue);
         if (appliedReleaseLabels.length > 1) {
             const errorMessage = 'More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.';
@@ -26,6 +27,9 @@ module.exports = {
         if (patch) {
             return 'patch';
         }
+        if (beta) {
+            return 'beta';
+        }
         return null;
     },
     incrementTag(latestTag, releaseType) {
@@ -36,6 +40,15 @@ module.exports = {
             );
         }
 
-        return 'v' + semver.inc(latestVersion, releaseType);
+        if (releaseType === 'beta') {
+            const isPrerelease = semver.prerelease(latestVersion);
+            if (isPrerelease) {
+                return 'v' + semver.inc(latestVersion, 'prerelease');
+            } else {
+                return 'v' + semver.inc(latestVersion, 'prerelease', 'beta');
+            }
+        } else {
+            return 'v' + semver.inc(latestVersion, releaseType);
+        }
     }
 };

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const proclaim = require('proclaim');
-const { highestReleaseTypeFromLabels, incrementTag } = require('../lib');
+const { releaseTypeFromLabels, incrementTag } = require('../lib');
 
-describe('highestReleaseTypeFromLabels', function () {
+describe('releaseTypeFromLabels', function () {
 	const majorLabel = 'release:major';
 	const minorLabel = 'release:minor';
 	const patchLabel = 'release:patch';
@@ -15,39 +15,53 @@ describe('highestReleaseTypeFromLabels', function () {
 
 	it('should return the corresponding release type given a single Origami release label', function () {
 		for (const { expectedType, releaseLabel } of Object.entries(typeToReleaseLabel)) {
-			const actualType = highestReleaseTypeFromLabels([releaseLabel]);
+			const actualType = releaseTypeFromLabels([releaseLabel]);
 			proclaim.equal(actualType, expectedType);
 		}
 	});
 
-	it('should return the highest release type given multiple labels', function () {
+	it('should throw an error if given multiple release type labels', function () {
 		const data = [
 			{
 				labels: ['release:major-test-dummy', minorLabel, majorLabel, patchLabel, 'zzz', 'aaa', '111'],
-				expectedType: 'major',
+				errorMessage: `More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.
+The labels which were applied are: [
+ "release:major-test-dummy",
+ "release:minor",
+ "release:major",
+ "release:patch",
+ "zzz",
+ "aaa",
+ "111"
+]`,
 			},
 			{
 				labels: ['release:lies', patchLabel, 'zzz', minorLabel, 'aaa', '111'],
-				expectedType: 'minor',
-			},
-			{
-				labels: ['release:major-test-dummy', 'zzz', 'aaa', '111', patchLabel],
-				expectedType: 'patch',
-			},
+				errorMessage: `More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.
+The labels which were applied are: [
+ "release:lies",
+ "release:patch",
+ "zzz",
+ "release:minor",
+ "aaa",
+ "111"
+]`,
+			}
 		];
-		for (const { labels, expectedType } of data) {
-			const actualType = highestReleaseTypeFromLabels(labels);
-			proclaim.equal(actualType, expectedType);
+		for (const { labels, errorMessage } of data) {
+			proclaim.throws(function(){
+				releaseTypeFromLabels(labels);
+			}, errorMessage);
 		}
 	});
 
 	it('should return `null` given no Origami release labels', function () {
-		const actualType = highestReleaseTypeFromLabels(['release:major-test-dummy', 'zzz', 'aaa', '111']);
+		const actualType = releaseTypeFromLabels(['release:major-test-dummy', 'zzz', 'aaa', '111']);
 		proclaim.isNull(actualType);
 	});
 
 	it('should return `null` given no labels at all', function () {
-		const actualType = highestReleaseTypeFromLabels([]);
+		const actualType = releaseTypeFromLabels([]);
 		proclaim.isNull(actualType);
 	});
 });

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -72,33 +72,79 @@ describe('incrementTag', function () {
 		proclaim.equal(incrementTag('v1.0.0', 'major'), 'v2.0.0');
 		proclaim.equal(incrementTag('v1.0.0', 'minor'), 'v1.1.0');
 		proclaim.equal(incrementTag('v1.0.0', 'patch'), 'v1.0.1');
+		proclaim.equal(incrementTag('v1.0.0', 'beta'), 'v1.0.1-beta.0');
 
 		// without a `v`
 		proclaim.equal(incrementTag('1.0.0', 'major'), 'v2.0.0');
 		proclaim.equal(incrementTag('1.0.0', 'minor'), 'v1.1.0');
 		proclaim.equal(incrementTag('1.0.0', 'patch'), 'v1.0.1');
+		proclaim.equal(incrementTag('1.0.0', 'beta'), 'v1.0.1-beta.0');
 	});
 
-	it('should increment a valid pre release semver tag by the release type', function () {
-		// releasing a major after a major pre-release releases that major
-		proclaim.equal(incrementTag('v2.0.0-beta.1', 'major'), 'v2.0.0');
-		// releasing a major after a minor/patch pre-release releases the next major
-		proclaim.equal(incrementTag('v2.0.1-beta.1', 'major'), 'v3.0.0');
-		proclaim.equal(incrementTag('v2.1.0-beta.1', 'major'), 'v3.0.0');
-		// releasing a minor after a minor pre-release releases that minor
-		proclaim.equal(incrementTag('v2.1.0-beta.1', 'minor'), 'v2.1.0');
-		// releasing a minor after a patch/major pre-release releases the next minor
-		proclaim.equal(incrementTag('v2.0.1-beta.1', 'minor'), 'v2.1.0');
-		// releasing a minor after a major pre-release releases the major
-		proclaim.equal(incrementTag('v2.0.0-beta.1', 'minor'), 'v2.0.0');
-		// releasing a patch after a minor pre-release releases that minor
-		proclaim.equal(incrementTag('v2.1.0-beta.1', 'minor'), 'v2.1.0');
-		// releasing a patch after a patch pre-release releases that patch
-		proclaim.equal(incrementTag('v2.0.1-beta.1', 'patch'), 'v2.0.1');
-		// releasing a patch after a minor pre-release releases the minor
-		proclaim.equal(incrementTag('v2.1.0-beta.1', 'patch'), 'v2.1.0');
-		// releasing a patch after a major pre-release releases the major
-		proclaim.equal(incrementTag('v2.0.0-beta.1', 'patch'), 'v2.0.0');
+	context('releasing a major after a major pre-release releases that major', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.0-beta.1', 'major'), 'v2.0.0');
+		});
+	});
+	context('releasing a major after a patch pre-release releases the next major', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.1-beta.1', 'major'), 'v3.0.0');
+		});
+	});
+	context('releasing a major after a minor pre-release releases the next major', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+				proclaim.equal(incrementTag('v2.1.0-beta.1', 'major'), 'v3.0.0');
+		});
+	});
+	context('releasing a minor after a minor pre-release releases that minor', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.1.0-beta.1', 'minor'), 'v2.1.0');
+		});
+	});
+	context('releasing a minor after a patch/major pre-release releases the next minor', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.1-beta.1', 'minor'), 'v2.1.0');
+		});
+	});
+	context('releasing a minor after a major pre-release releases the major', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.0-beta.1', 'minor'), 'v2.0.0');
+		});
+	});
+	context('releasing a minor after a minor pre-release releases that minor', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.1.0-beta.1', 'minor'), 'v2.1.0');
+		});
+	});
+	context('releasing a patch after a patch pre-release releases that patch', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.1-beta.1', 'patch'), 'v2.0.1');
+		});
+	});
+	context('releasing a patch after a minor pre-release releases the minor', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.1.0-beta.1', 'patch'), 'v2.1.0');
+		});
+	});
+	context('releasing a patch after a major pre-release releases the major', function(){
+		it('should increment a valid pre release semver tag by the release type', function () {
+			proclaim.equal(incrementTag('v2.0.0-beta.1', 'patch'), 'v2.0.0');
+		});
+	});
+	context('releasing a beta after a patch pre-release releases that patch', function(){
+		it('should increment the pre release version', function () {
+			proclaim.equal(incrementTag('v2.0.1-beta.1', 'beta'), 'v2.0.1-beta.2');
+		});
+	});
+	context('releasing a beta after a minor pre-release releases the minor', function(){
+		it('should increment the pre release version', function () {
+			proclaim.equal(incrementTag('v2.1.0-beta.1', 'beta'), 'v2.1.0-beta.2');
+		});
+	});
+	context('releasing a beta after a major pre-release releases the major', function(){
+		it('should increment the pre release version', function () {
+			proclaim.equal(incrementTag('v2.0.0-beta.1', 'beta'), 'v2.0.0-beta.2');
+		});
 	});
 
 	it('should increment a valid semver tag with whitespace by the release type', function () {


### PR DESCRIPTION
This is a stacked pull-request. It is stacked off of https://github.com/Financial-Times/origami-version/pull/109

The current behavior which exists in origami-version is to choose the highest release label if multiple were applied. We should change this behaviour to throw an error because if multiple release labels are applied, we don't actually know that they wanted to use the highest label for the release, it is safer to throw an error.

Future work we could do in origami-version is to run the action on every pushed commit to the pull-request and fail the build if the pull-request has mulitple release labels applied. This would stop the pull-request from ever being able to be merged with multiple release labels applied.This change adds the ability for a release label named 'release:beta' to
be used to release a prerelease version.

If the current release is itself a prerelease version then the
prerelease number is incremented.
If the current version is not a prerelease then the current version has
`beta.0` appended to it.