### PR TITLE
WIP Draft: Commit version to package.json, support more beta labels

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,54 +1,42 @@
 'use strict';
-const semver = require('semver');
-
-function isTrue(bool) {
-    return bool === true;
-}
 
 module.exports = {
     releaseTypeFromLabels(labels = []) {
-        // Possible release types
-        // 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease'
-        const major = labels.includes('release:major');
-        const minor = labels.includes('release:minor');
-        const patch = labels.includes('release:patch');
-        const beta = labels.includes('release:beta');
-        const appliedReleaseLabels = [major, minor, patch, beta].filter(isTrue);
-        if (appliedReleaseLabels.length > 1) {
-            const errorMessage = 'More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.';
-            throw new Error(errorMessage + '\n' + `The labels which were applied are: ${JSON.stringify(labels, undefined, 1)}`);
-        }
-        if (major) {
-            return 'major';
-        }
-        if (minor) {
-            return 'minor';
-        }
-        if (patch) {
-            return 'patch';
-        }
-        if (beta) {
-            return 'beta';
-        }
-        return null;
-    },
-    incrementTag(latestTag, releaseType) {
-        const latestVersion = semver.clean(latestTag);
-        if (!latestVersion) {
-            throw new Error(
-                `Could not find latest version from tag "${latestTag}".`
-            );
+        const majorLabel = 'release:major';
+        const minorLabel = 'release:minor';
+        const patchLabel = 'release:patch';
+        const betaLabel = 'release:beta';
+
+        // Check there are no conflicting labels. Major/Minor/Patch can not be
+        // used together but can be used with a Beta label.
+        const incrementLabels = [majorLabel, minorLabel, patchLabel];
+        const appliedIncrementLabels = labels.filter(
+            label => incrementLabels.includes(label)
+        );
+        if (appliedIncrementLabels.length > 1) {
+            throw new Error('Conflicting release labels were applied, ' +
+                'origami-version can not determine the correct version to .' +
+                'release\nApply only one of the conflicting labels:' +
+                `${appliedIncrementLabels}`);
         }
 
-        if (releaseType === 'beta') {
-            const isPrerelease = semver.prerelease(latestVersion);
-            if (isPrerelease) {
-                return 'v' + semver.inc(latestVersion, 'prerelease');
-            } else {
-                return 'v' + semver.inc(latestVersion, 'prerelease', 'beta');
-            }
-        } else {
-            return 'v' + semver.inc(latestVersion, releaseType);
+        const major = labels.includes(majorLabel);
+        const minor = labels.includes(minorLabel);
+        const patch = labels.includes(patchLabel);
+        const beta = labels.includes(betaLabel);
+
+        if (major) {
+            return `${beta ? 'pre' : ''}major`;
         }
+        if (minor) {
+            return `${beta ? 'pre' : ''}minor`;
+        }
+        if (patch) {
+            return `${beta ? 'pre' : ''}patch`;
+        }
+        if (beta) {
+            return 'prerelease';
+        }
+        return null;
     }
 };


### PR DESCRIPTION
- Make the beta label a modifier so we can release premajor, preminor,
prepatch etc. using Github labels
 https://github.com/Financial-Times/origami-version/issues/114
- Commit the version number to package.json for Origami v2 components:
https://github.com/Financial-Times/o-brand/pull/85