### PR TITLE
Add ability to automatically release a major/minor/patch beta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,34 +1,42 @@
 'use strict';
 const semver = require('semver');
 
-function isTrue(bool) {
-    return bool === true;
-}
-
 module.exports = {
     releaseTypeFromLabels(labels = []) {
-        // Possible release types
-        // 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease'
-        const major = labels.includes('release:major');
-        const minor = labels.includes('release:minor');
-        const patch = labels.includes('release:patch');
-        const beta = labels.includes('release:beta');
-        const appliedReleaseLabels = [major, minor, patch, beta].filter(isTrue);
-        if (appliedReleaseLabels.length > 1) {
-            const errorMessage = 'More than one release label was applied, origami-version only works when one release label is applied to avoid behaviour a user may find surprising.';
-            throw new Error(errorMessage + '\n' + `The labels which were applied are: ${JSON.stringify(labels, undefined, 1)}`);
+        const majorLabel = 'release:major';
+        const minorLabel = 'release:minor';
+        const patchLabel = 'release:patch';
+        const betaLabel = 'release:beta';
+
+        // Check there are no conflicting labels. Major/Minor/Patch can not be
+        // used together but can be used with a Beta label.
+        const incrementLabels = [majorLabel, minorLabel, patchLabel];
+        const appliedIncrementLabels = labels.filter(
+            label => incrementLabels.includes(label)
+        );
+        if (appliedIncrementLabels.length > 1) {
+            throw new Error('Conflicting release labels were applied, ' +
+                'origami-version can not determine the correct version to ' +
+                'release. Apply only one of: "' +
+                `${appliedIncrementLabels.join('", "')}".`);
         }
+
+        const major = labels.includes(majorLabel);
+        const minor = labels.includes(minorLabel);
+        const patch = labels.includes(patchLabel);
+        const beta = labels.includes(betaLabel);
+
         if (major) {
-            return 'major';
+            return `${beta ? 'pre' : ''}major`;
         }
         if (minor) {
-            return 'minor';
+            return `${beta ? 'pre' : ''}minor`;
         }
         if (patch) {
-            return 'patch';
+            return `${beta ? 'pre' : ''}patch`;
         }
         if (beta) {
-            return 'beta';
+            return 'prerelease';
         }
         return null;
     },
@@ -40,15 +48,23 @@ module.exports = {
             );
         }
 
-        if (releaseType === 'beta') {
-            const isPrerelease = semver.prerelease(latestVersion);
-            if (isPrerelease) {
-                return 'v' + semver.inc(latestVersion, 'prerelease');
-            } else {
-                return 'v' + semver.inc(latestVersion, 'prerelease', 'beta');
-            }
-        } else {
-            return 'v' + semver.inc(latestVersion, releaseType);
+        // If there's already a beta ignore new pre-releases and increment the
+        // current beta instead. This is to defend against users accidentally
+        // releasing a beta for a future version which is not being worked on.
+        // E.g. Given a PR based on a current beta `v2.0.0-beta.0`, the release
+        // tags 'release:major' and 'release:beta' will release `v2.0.0-beta.1`,
+        // not `v3.0.0-beta.0`.
+        const latestIsPreRelease = semver.prerelease(latestVersion);
+        const newPreRelease = [
+            'premajor',
+            'preminor',
+            'prepatch'
+        ].includes(releaseType);
+        if (latestIsPreRelease && newPreRelease) {
+            return 'v' + semver.inc(latestVersion, 'prerelease', 'beta');
         }
+
+        // The 'beta' identifier is only used for pre-releases.
+        return 'v' + semver.inc(latestVersion, releaseType, 'beta');
     }
 };


### PR DESCRIPTION
Given the last release was not a prerelease and:
- release:major and release:beta labels are applied: do an npm version premajor
- release:minor and release:beta labels are applied: do an npm version preminor
- release:patch and release:beta labels are applied: do an npm version prepatch
- release:beta label alone is applied: do an npm version prerelease

Given the last release was a prerelease and:
- release:beta with any other release label: do an npm version
prerelease to increment the current beta.

Existing prereleases are only incremented with the `release:beta`
and any other release label to defend against users accidentally
releasing a beta for a future version which is not being worked on.
E.g. Given a PR based on a current beta `v2.0.0-beta.0`, the release
tags 'release:major' and 'release:beta' will release `v2.0.0-beta.1`,
not `v3.0.0-beta.0`.

Fixes: https://github.com/Financial-Times/origami-version/issues/114