### PR TITLE
Update `create-release-pr.yml` tags-ignore to match fewer refs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -6,7 +6,7 @@ name: Create A Release Pull Request
 on:
   pull_request:
     types: [closed] # Merged pull-requests count as closed pull-requests.
-    tags-ignore: '**'  # When there are no tags
+    tags-ignore: 'v*'  # When there are no version tags
 jobs:
   create-version-pr:
     name: Create A Pull Request To Release A New Version


### PR DESCRIPTION
Merging this PR did not run the workflow
`create-release-pr.yml` as expected. These docs aren't super clear
to me, could this help?
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags
https://github.com/Financial-Times/origami-version/pull/132