### PR TITLE
Revert "Attempt to skip review check when auto committing build to ma…

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/checkout@v2
         if: github.event.pull_request.merged # Only run on merged pull-requests
         with:
-          token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.merge_commit_sha }} # Checkout the merged commit
           fetch-depth: 0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin


### PR DESCRIPTION
…ster (#127)"

This reverts commit 85d3b9f908570183a4c1d7b88899d6964c1799e1.

We decided to remove branch protections for the repo, for now, with
the view of potentially replacing it by moving to Semantic Release
in the future: https://github.com/semantic-release/semantic-release